### PR TITLE
sd.system.dimension.spacing.noneの追加に伴うデザイントークンのアップデート

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@astrojs/react": "^3.6.0",
         "@eslint/js": "^9.15.0",
         "@pandacss/eslint-plugin": "^0.2.2",
-        "@serendie/design-token": "0.1.1",
+        "@serendie/design-token": "^0.2.0",
         "@serendie/style-dictionary-formatter": "^0.0.2",
         "@serendie/symbols": "^0.0.10",
         "@serendie/ui": "^0.1.4",
@@ -3295,9 +3295,9 @@
       ]
     },
     "node_modules/@serendie/design-token": {
-      "version": "0.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@serendie/design-token/0.1.1/d276f6852b3eb094cf13ca1b5282f6518a0a469a",
-      "integrity": "sha512-RYQeLnIYJ7e1uysyhNkJ+P4eMbT72zX6FJJKYWgfLpRiuEFlaXWX6w+tyRuecc7C9NtNgJnISyhiORRRQIm1qw==",
+      "version": "0.2.0",
+      "resolved": "https://npm.pkg.github.com/download/@serendie/design-token/0.2.0/318230122f05120059dbfaebce9989e385023b52",
+      "integrity": "sha512-b034xkftNJNp5Lv88QJ8tdYeVSpljBm98QavwdPhpEI2ZdFcIZsuz5GAfFZj6jqJMGPotgvOcNSh4zUjyPvKGw==",
       "dependencies": {
         "axios": "^1.6.7",
         "deepmerge": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@astrojs/react": "^3.6.0",
     "@eslint/js": "^9.15.0",
     "@pandacss/eslint-plugin": "^0.2.2",
-    "@serendie/design-token": "0.1.1",
+    "@serendie/design-token": "^0.2.0",
     "@serendie/style-dictionary-formatter": "^0.0.2",
     "@serendie/symbols": "^0.0.10",
     "@serendie/ui": "^0.1.4",


### PR DESCRIPTION
ref: https://github.com/serendie/internal/pull/438

`sd.system.dimension.spacing.none`の追加に伴い、
`@serendie/design-token`のバージョンを`0.1.1`から`0.2.0`へ更新しました。