### PR TITLE
ドキュメントの見出し関連のマージン修正

### DIFF
--- a/src/components/PageHeadLine.astro
+++ b/src/components/PageHeadLine.astro
@@ -58,7 +58,7 @@ export const snackBarClassName = css({
         gap: "sd.system.dimension.spacing.small",
       },
       expanded: {
-        mb: "32px"
+        mb: "24px"
       }
     })}`}
   >

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -46,7 +46,7 @@ export const PageSection = styled("section", {
     },
     "& p": {
       lineHeight: "1.7",
-      mt: "sd.system.dimension.spacing.extraLarge",
+      mt: "sd.system.dimension.spacing.medium",
     },
     "& p + p:has(img), & p + img, & p + svg, & p + figure, & p + pre, & p + a, & .codeBox":
       {
@@ -63,7 +63,13 @@ export const PageSection = styled("section", {
       mb: "sd.system.dimension.spacing.medium",
       expanded: {
         mt: "sd.system.dimension.spacing.twoExtraLarge",
-        mb: "sd.system.dimension.spacing.extraLarge",
+        mb: "sd.system.dimension.spacing.medium",
+      },
+    },
+    "& astro-page-headline + h2": {
+      mt: "sd.system.dimension.spacing.extraLarge",
+      expanded: {
+        mt: "sd.system.dimension.spacing.extraLarge",
       },
     },
     "& h2": {


### PR DESCRIPTION
PageHeadLine.astro:
- Adjusted margin-bottom from 32px to 24px.

PageLayout.tsx:
- Changed margin-top for paragraphs from extraLarge to medium.
- Updated margin-bottom for expanded state from extraLarge to medium.
- Added margin-top for astro-page-headline + h2.