### PR TITLE
カラーパレットの順序を降順から昇順にする

### DIFF
--- a/src/components/ColorMatrix.astro
+++ b/src/components/ColorMatrix.astro
@@ -26,7 +26,7 @@ export function getColorValue(color: keyof typeof colorScale, shade: string) {
 }
 
 function getShades(color: keyof typeof colorScale) {
-  return Object.keys(colorScale[color]).reverse();
+  return Object.keys(colorScale[color]);
 }
 
 function toCamelCase(color: string) {


### PR DESCRIPTION
色のシェードを取得する関数で、シェードの順序を逆にしないように修正しました。