### PR TITLE
サイドバーのページの順番が上下してしまう問題の修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -988,7 +988,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -45,6 +45,13 @@ const siblings = await getCollection(
     !page.data.parent
 );
 
+// Sort siblings by filename with natural numeric sorting
+siblings.sort((a, b) => {
+  const filenameA = a.id.split("/").pop() || "";
+  const filenameB = b.id.split("/").pop() || "";
+  return filenameA.localeCompare(filenameB, undefined, { numeric: true, sensitivity: 'base' });
+});
+
 const propsForMdx = {
   siblings,
 };


### PR DESCRIPTION
ファイル名を元にしたソートの追加を行いました。これにより、Astro のビルドキャッシュなどに影響されていた並び順が、意図通りになります。