### PR TITLE
 DatePickerコンポーネントのページ追加 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@serendie/design-token": "dev",
         "@serendie/style-dictionary-formatter": "^0.0.3",
         "@serendie/symbols": "^1.0.1",
-        "@serendie/ui": "npm:@serendie/ui@dev",
+        "@serendie/ui": "^2.1.3-dev.202509040333",
         "@types/eslint__js": "^8.42.3",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -988,6 +988,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4309,9 +4310,9 @@
       }
     },
     "node_modules/@serendie/ui": {
-      "version": "2.1.3-dev.202509030422",
-      "resolved": "https://registry.npmjs.org/@serendie/ui/-/ui-2.1.3-dev.202509030422.tgz",
-      "integrity": "sha512-gkh18/edybpgfn+UTMrtCweTRLQMoUQcvh4gXriVOoFmfXeWRDMI7oBFe1sSyk3O9iqrcDb6QeSas0cgo4X85Q==",
+      "version": "2.1.3-dev.202509040333",
+      "resolved": "https://registry.npmjs.org/@serendie/ui/-/ui-2.1.3-dev.202509040333.tgz",
+      "integrity": "sha512-ixrpunlavyc2jq6qZghd585skkMcB4ZNNRLz/Z2BFOGQWLRQErxrbe+vH5o8R3f0z7MQzP6mTfrjM75nXDunTQ==",
       "license": "MIT",
       "dependencies": {
         "@ark-ui/react": "^5.18.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@serendie/design-token": "dev",
         "@serendie/style-dictionary-formatter": "^0.0.3",
         "@serendie/symbols": "^1.0.1",
-        "@serendie/ui": "dev",
+        "@serendie/ui": "npm:@serendie/ui@dev",
         "@types/eslint__js": "^8.42.3",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -988,7 +988,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4310,11 +4309,12 @@
       }
     },
     "node_modules/@serendie/ui": {
-      "version": "2.1.1-dev.202507310807",
-      "resolved": "https://registry.npmjs.org/@serendie/ui/-/ui-2.1.1-dev.202507310807.tgz",
-      "integrity": "sha512-kpRL6JlVmCblYQIcvHEApoz4Nmusl/uPnQQSXxLEg3kMl5aUmccJPLVdFgn305yJLZXn6ftqhPIInR3ctDaEhA==",
+      "version": "2.1.3-dev.202509030422",
+      "resolved": "https://registry.npmjs.org/@serendie/ui/-/ui-2.1.3-dev.202509030422.tgz",
+      "integrity": "sha512-gkh18/edybpgfn+UTMrtCweTRLQMoUQcvh4gXriVOoFmfXeWRDMI7oBFe1sSyk3O9iqrcDb6QeSas0cgo4X85Q==",
+      "license": "MIT",
       "dependencies": {
-        "@ark-ui/react": "^5.13.0",
+        "@ark-ui/react": "^5.18.0",
         "@nivo/bar": "^0.99.0",
         "@nivo/core": "^0.99.0",
         "@nivo/line": "^0.99.0",
@@ -4331,7 +4331,7 @@
         "@rollup/rollup-linux-x64-gnu": "^4.14.3"
       },
       "peerDependencies": {
-        "@ark-ui/react": "^5.13.0",
+        "@ark-ui/react": "^5.18.0",
         "react": ">=18.3.1",
         "react-dom": ">=18.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@serendie/design-token": "dev",
     "@serendie/style-dictionary-formatter": "^0.0.3",
     "@serendie/symbols": "^1.0.1",
-    "@serendie/ui": "dev",
+    "@serendie/ui": "npm:@serendie/ui@dev",
     "@types/eslint__js": "^8.42.3",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@serendie/design-token": "dev",
     "@serendie/style-dictionary-formatter": "^0.0.3",
     "@serendie/symbols": "^1.0.1",
-    "@serendie/ui": "npm:@serendie/ui@dev",
+    "@serendie/ui": "^2.1.3-dev.202509040333",
     "@types/eslint__js": "^8.42.3",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/src/content/components/date-picker.mdx
+++ b/src/content/components/date-picker.mdx
@@ -1,0 +1,41 @@
+---
+title: DatePicker
+componentName: デートピッカー
+description: 日付を選択するためのコンポーネントです。カレンダー形式で日付を選択できます。
+lastUpdated: "2025-09-03"
+---
+
+import Code from "@/components/Code.astro";
+import { BasicSample } from "@/sampleCode/DatePicker/BasicSample";
+import basicSampleRaw from "@/sampleCode/DatePicker/BasicSample.tsx?raw";
+import { RangeSample } from "@/sampleCode/DatePicker/RangeSample";
+import rangeSampleRaw from "@/sampleCode/DatePicker/RangeSample.tsx?raw";
+import { StateSample } from "@/sampleCode/DatePicker/StateSample";
+import stateSampleRaw from "@/sampleCode/DatePicker/StateSample.tsx?raw";
+
+<Code
+  title="基本"
+  description="単一の日付を選択する基本的なデートピッカーです。"
+  code={basicSampleRaw}
+  storyPath="/story/components-datepicker--basic"
+>
+  <BasicSample client:load />
+</Code>
+
+<Code
+  title="日付範囲"
+  description="開始日と終了日を選択できる範囲選択型のデートピッカーです。"
+  code={rangeSampleRaw}
+  storyPath="/story/components-datepicker--range"
+>
+  <RangeSample client:load />
+</Code>
+
+<Code
+  title="状態"
+  description="4種類の状態があります。入力必須とする際はrequired propsを使用し、非活性とする際はdisabled propsを使用してください。"
+  code={stateSampleRaw}
+  storyPath="/story/components-datepicker--states"
+>
+  <StateSample client:load />
+</Code>

--- a/src/sampleCode/DatePicker/BasicSample.tsx
+++ b/src/sampleCode/DatePicker/BasicSample.tsx
@@ -1,0 +1,5 @@
+import { DatePicker } from "@serendie/ui";
+
+export function BasicSample() {
+  return <DatePicker label="日付を選択" placeholder="YYYY/MM/DD" />;
+}

--- a/src/sampleCode/DatePicker/RangeSample.tsx
+++ b/src/sampleCode/DatePicker/RangeSample.tsx
@@ -1,0 +1,5 @@
+import { DatePicker } from "@serendie/ui";
+
+export function RangeSample() {
+  return <DatePicker label="期間を選択" selectionMode="range" />;
+}

--- a/src/sampleCode/DatePicker/StateSample.tsx
+++ b/src/sampleCode/DatePicker/StateSample.tsx
@@ -1,0 +1,38 @@
+import { parseDate } from "@ark-ui/react";
+import { DatePicker } from "@serendie/ui";
+import { Dd, Dl, Dt } from "src/components/LayoutUtils";
+
+export function StateSample() {
+  return (
+    <Dl>
+      <Dt>Enabled</Dt>
+      <Dd>
+        <DatePicker label="日付" placeholder="YYYY/MM/DD" />
+      </Dd>
+      <Dt>Filled</Dt>
+      <Dd>
+        <DatePicker
+          label="日付"
+          placeholder="YYYY/MM/DD"
+          required
+          value={[parseDate("2025-09-03")]}
+        />
+      </Dd>
+      <Dt>Error</Dt>
+      <Dd>
+        <DatePicker
+          label="日付"
+          placeholder="YYYY/MM/DD"
+          required
+          invalid
+          invalidMessage="正しい日付を入力してください"
+          value={[parseDate("2025-09-03")]}
+        />
+      </Dd>
+      <Dt>Disabled</Dt>
+      <Dd>
+        <DatePicker label="日付" placeholder="YYYY/MM/DD" disabled />
+      </Dd>
+    </Dl>
+  );
+}

--- a/src/sampleCode/DatePicker/StateSample.tsx
+++ b/src/sampleCode/DatePicker/StateSample.tsx
@@ -1,5 +1,4 @@
-import { parseDate } from "@ark-ui/react";
-import { DatePicker } from "@serendie/ui";
+import { DatePicker, parseDate } from "@serendie/ui";
 import { Dd, Dl, Dt } from "src/components/LayoutUtils";
 
 export function StateSample() {


### PR DESCRIPTION
DatePickerコンポーネントのドキュメントを追加

### 変更内容

- DatePickerコンポーネントのドキュメントページを追加
- 3つのサンプルコードを実装：
  - 基本的な日付選択
  - 日付範囲選択
  - 状態（required/disabled）のデモ

**パッケージ更新**
- `@serendie/ui`をdev版に更新（DatePickerコンポーネントの最新版を使用）

**追加ファイル**
- `src/content/components/date-picker.mdx` - コンポーネントドキュメント
- `src/sampleCode/DatePicker/BasicSample.tsx` - 基本サンプル
- `src/sampleCode/DatePicker/RangeSample.tsx` - 範囲選択サンプル
- `src/sampleCode/DatePicker/StateSample.tsx` - 状態サンプル

<img width="930" height="1646" alt="image" src="https://github.com/user-attachments/assets/8222b32e-1bd9-47d1-a049-9458937b7d2f" />
