### PR TITLE
MCPツールにてDataTableコンポーネントが読み込まれない問題を修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@serendie/design-token": "dev",
         "@serendie/style-dictionary-formatter": "^0.0.3",
         "@serendie/symbols": "^1.0.1",
-        "@serendie/ui": "^2.1.3-dev.202509170003",
+        "@serendie/ui": "^2.2.0",
         "@types/eslint__js": "^8.42.3",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -988,6 +988,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4309,9 +4310,9 @@
       }
     },
     "node_modules/@serendie/ui": {
-      "version": "2.1.3-dev.202509170003",
-      "resolved": "https://registry.npmjs.org/@serendie/ui/-/ui-2.1.3-dev.202509170003.tgz",
-      "integrity": "sha512-tKTJQG0YWDttuJY7wmPmfAkeM7EFN4YegAldVjaoysv2aTWTVtejquO/wCl3UEuakdaZydlQT2HBiG41Ijf9NQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@serendie/ui/-/ui-2.2.0.tgz",
+      "integrity": "sha512-VdTlUrhjln0WB26Pm7UoZiLejdGKRFHgLgwCGHUe+iYC+iwsb1euwzhVGmC7mKmreKMwYIQKJUyN6NdhbwYdlA==",
       "license": "MIT",
       "dependencies": {
         "@ark-ui/react": "^5.18.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@serendie/design-token": "dev",
     "@serendie/style-dictionary-formatter": "^0.0.3",
     "@serendie/symbols": "^1.0.1",
-    "@serendie/ui": "^2.1.3-dev.202509170003",
+    "@serendie/ui": "^2.2.0",
     "@types/eslint__js": "^8.42.3",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/src/mcp/data/component-categories.ts
+++ b/src/mcp/data/component-categories.ts
@@ -42,6 +42,7 @@ export const componentCategories: Record<string, ComponentCategory> = {
       "List",
       "ListItem",
       "TopAppBar",
+      "DataTable",
     ],
   },
   Display: {


### PR DESCRIPTION
DataTableコンポーネントのような、複数のコンポーネント関数がまとまったコンポーネントが、MCPサーバーで利用するPropsの型解析スクリプト上で読み込まれない問題を修正しました。

DataTableの実装：
https://github.com/serendie/serendie/blob/main/src/components/DataTable/index.ts