### PR TITLE
MCPのコンポーネントレスポンスを修正

### DIFF
--- a/src/mcp/__tests__/tools/components.test.ts
+++ b/src/mcp/__tests__/tools/components.test.ts
@@ -211,6 +211,15 @@ const mockComponentsManifest = [
   },
 ];
 
+const toComponentSlug = (name: string) =>
+  name
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
+    .replace(/([a-z\d])([A-Z])/g, "$1-$2")
+    .replace(/-{2,}/g, "-")
+    .toLowerCase();
+
 // Setup mock before tests
 beforeAll(() => {
   vi.mocked(readFile).mockResolvedValue(JSON.stringify(mockComponentsManifest));
@@ -352,6 +361,7 @@ describe("Components Tools", () => {
           categories,
           components: mockComponentsManifest.map((component) => ({
             name: component.name,
+            slug: toComponentSlug(component.name),
             displayName: component.displayName,
             description: component.description,
             category: component.category,
@@ -372,6 +382,7 @@ describe("Components Tools", () => {
         const component = mockComponentsManifest[0];
         const summary = {
           name: component.name,
+          slug: toComponentSlug(component.name),
           displayName: component.displayName,
           description: component.description,
           category: component.category,
@@ -393,6 +404,7 @@ describe("Components Tools", () => {
           categories: ["Actions", "Feedback", "Inputs", "Layout"],
           components: mockComponentsManifest.map((c) => ({
             name: c.name,
+            slug: toComponentSlug(c.name),
             displayName: c.displayName,
             description: c.description,
             category: c.category,
@@ -462,30 +474,27 @@ describe("Components Tools", () => {
     describe("Expected Output Structure", () => {
       it("should return correct structure for existing component", () => {
         const component = mockComponentsManifest[0];
+        const componentSlug = toComponentSlug(component.name);
+        const exportName = component.name.replace(/\s+/g, "");
         const expectedOutput = {
           name: component.name,
+          slug: componentSlug,
           exists: true,
           displayName: component.displayName,
           description: component.description,
           category: component.category,
           lastUpdated: component.lastUpdated,
-          importStatement: `import { ${component.name} } from "@serendie/ui/${component.name
-            .replace(/([A-Z])/g, "-$1")
-            .toLowerCase()
-            .replace(/^-/, "")}";`,
+          importStatement: `import { ${exportName} } from "@serendie/ui";`,
           documentationUrl: component.hasDocumentation
-            ? `https://serendie.design/components/${component.name
-                .replace(/([A-Z])/g, "-$1")
-                .toLowerCase()
-                .replace(/^-/, "")}`
+            ? `https://serendie.design/components/${componentSlug}`
             : null,
           props: component.props,
           examples: component.examples,
           storybookUrls: component.storybookUrls,
           relatedComponents: component.relatedComponents,
           usage: {
-            basic: `<${component.name}>Content</${component.name}>`,
-            withProps: `<${component.name} prop="value">Content</${component.name}>`,
+            basic: `<${exportName}>Content</${exportName}>`,
+            withProps: `<${exportName} prop="value">Content</${exportName}>`,
           },
         };
 
@@ -518,13 +527,13 @@ describe("Components Tools", () => {
 
       it("should generate correct import statement", () => {
         const component = mockComponentsManifest[0];
-        const importStatement = `import { ${component.name} } from "@serendie/ui/${component.name
-          .replace(/([A-Z])/g, "-$1")
-          .toLowerCase()
-          .replace(/^-/, "")}";`;
+        const importStatement = `import { ${component.name.replace(
+          /\s+/g,
+          ""
+        )} } from "@serendie/ui";`;
 
         expect(importStatement).toBe(
-          'import { Button } from "@serendie/ui/button";'
+          'import { Button } from "@serendie/ui";'
         );
       });
 
@@ -603,15 +612,18 @@ describe("Components Tools", () => {
 
       it("should pass schema validation for component detail response", () => {
         const component = mockComponentsManifest[0];
+        const componentSlug = toComponentSlug(component.name);
+        const exportName = component.name.replace(/\s+/g, "");
         const response = {
           name: component.name,
+          slug: componentSlug,
           exists: true as const,
           displayName: component.displayName,
           description: component.description,
           category: component.category,
           lastUpdated: component.lastUpdated,
-          documentationUrl: `https://serendie.design/components/${component.name.toLowerCase()}`,
-          importStatement: `import { ${component.name} } from "@serendie/ui/${component.name.toLowerCase()}";`,
+          documentationUrl: `https://serendie.design/components/${componentSlug}`,
+          importStatement: `import { ${exportName} } from "@serendie/ui";`,
           props: component.props,
           examples: component.examples,
           storybookUrls: component.storybookUrls.map((url) => ({
@@ -620,8 +632,8 @@ describe("Components Tools", () => {
           })),
           relatedComponents: component.relatedComponents,
           usage: {
-            basic: `<${component.name}>Content</${component.name}>`,
-            withProps: `<${component.name} styleType="value" size="value">Content</${component.name}>`,
+            basic: `<${exportName}>Content</${exportName}>`,
+            withProps: `<${exportName} styleType="value" size="value">Content</${exportName}>`,
           },
         };
 

--- a/src/mcp/schemas/components.ts
+++ b/src/mcp/schemas/components.ts
@@ -29,6 +29,7 @@ export const StorybookUrlSchema = z.object({
 // コンポーネントサマリー（get-components用）
 export const ComponentSummarySchema = z.object({
   name: z.string(),
+  slug: z.string(),
   displayName: z.string(),
   description: z.string(),
   category: z.string(),
@@ -55,6 +56,7 @@ export const RelatedComponentSchema = z.object({
 // コンポーネント詳細（get-component-detail用）
 export const ComponentDetailSchema = z.object({
   name: z.string(),
+  slug: z.string(),
   exists: z.literal(true),
   displayName: z.string(),
   description: z.string(),


### PR DESCRIPTION
  - コンポーネント一覧/詳細レスポンスに slug を追加し、ケバブケース URL と一致させる共通ヘルパーを導入 (src/mcp/tools/components.ts, src/mcp/schemas/
    components.ts)。
  - インポート例をルートエントリからの複数同時 import 形式に統一し、スペースを含む名前でも正しい JSX タグ名になるよう調整。
  - テスト期待値を新しいレスポンス構造・インポート形式に合わせて更新 (src/mcp/__tests__/tools/components.test.ts)。
