### PR TITLE
doc-searchをMCPのtoolとして使えるように移植

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,6 +34,12 @@ export default tsESLint.config(
   ...tsESLint.configs.recommended,
   prettierRecommended,
   {
-    ignores: ["dist/", "styled-system/", "**/*.cjs", "tokens/generated/"],
+    ignores: [
+      ".astro/",
+      "dist/",
+      "styled-system/",
+      "**/*.cjs",
+      "tokens/generated/",
+    ],
   }
 );

--- a/src/mcp/__tests__/tools/search-design-docs.test.ts
+++ b/src/mcp/__tests__/tools/search-design-docs.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getSearchDesignDocsTools } from "../../tools/search-design-docs";
+
+type RegisteredHandler = (params: {
+  query: string;
+  nResults?: number;
+}) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  structuredContent?: unknown;
+  isError?: boolean;
+}>;
+
+const registerTools = () => {
+  const handlers = new Map<string, RegisteredHandler>();
+  const configs = new Map<string, { title: string; description: string }>();
+
+  const mockMcpServer = {
+    registerTool: (
+      name: string,
+      config: { title: string; description: string },
+      handler: RegisteredHandler
+    ) => {
+      configs.set(name, config);
+      handlers.set(name, handler);
+    },
+  };
+
+  getSearchDesignDocsTools(
+    mockMcpServer as Parameters<typeof getSearchDesignDocsTools>[0]
+  );
+
+  return { configs, handlers };
+};
+
+describe("search design docs MCP tools", () => {
+  const originalEndpoint = process.env.DOCS_SEARCH_API_ENDPOINT;
+  const originalApiKey = process.env.DOCS_SEARCH_API_KEY;
+
+  beforeEach(() => {
+    process.env.DOCS_SEARCH_API_ENDPOINT = "https://example.com/api/search";
+    process.env.DOCS_SEARCH_API_KEY = "test-api-key";
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    if (originalEndpoint === undefined) {
+      delete process.env.DOCS_SEARCH_API_ENDPOINT;
+    } else {
+      process.env.DOCS_SEARCH_API_ENDPOINT = originalEndpoint;
+    }
+    if (originalApiKey === undefined) {
+      delete process.env.DOCS_SEARCH_API_KEY;
+    } else {
+      process.env.DOCS_SEARCH_API_KEY = originalApiKey;
+    }
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("registers component and design token search tools", () => {
+    const { configs } = registerTools();
+
+    expect(configs.get("search-component-docs")?.title).toBe(
+      "Search Component Docs"
+    );
+    expect(configs.get("search-design-token-docs")?.title).toBe(
+      "Search Design Token Docs"
+    );
+  });
+
+  it("searches ark_ui and component_gallery for component docs", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [
+          {
+            id: "accordion",
+            score: 0.9,
+            source: "ark_ui",
+            title: "Accordion",
+            url: "https://ark-ui.com/react/docs/components/accordion",
+            text: "Accordion guidance",
+            metadata: { image: "data:image/png;base64,abc" },
+          },
+        ],
+        total: 1,
+      }),
+    } as Response);
+
+    const { handlers } = registerTools();
+    const result = await handlers.get("search-component-docs")!({
+      query: "accordion",
+      nResults: 3,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://example.com/api/search",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-API-Key": "test-api-key",
+        },
+        body: JSON.stringify({
+          query: "accordion",
+          n_results: 3,
+          source_filter: "ark_ui",
+        }),
+      })
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://example.com/api/search",
+      expect.objectContaining({
+        body: JSON.stringify({
+          query: "accordion",
+          n_results: 3,
+          source_filter: "component_gallery",
+        }),
+      })
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain("[image data removed]");
+    expect(result.content[0].text).not.toContain("data:image/png;base64");
+  });
+
+  it("searches m3 for design token docs", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [], total: 0 }),
+    } as Response);
+
+    const { handlers } = registerTools();
+    await handlers.get("search-design-token-docs")!({ query: "color role" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.com/api/search",
+      expect.objectContaining({
+        body: JSON.stringify({
+          query: "color role",
+          n_results: 5,
+          source_filter: "m3",
+        }),
+      })
+    );
+  });
+
+  it("returns MCP tool errors when doc-search API fails", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      text: async () => "search failed",
+    } as Response);
+
+    const { handlers } = registerTools();
+    const result = await handlers.get("search-design-token-docs")!({
+      query: "typography",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Doc search request failed");
+    expect(result.content[0].text).toContain("search failed");
+  });
+});

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -10,6 +10,7 @@ import { getSerendieUIOverviewTool } from "./tools/serendie-ui-overview";
 // This avoids fs usage and works in Cloudflare Workers
 import previewHtml from "./ui/preview.html?raw";
 import { getSearchSerendieGuidelineTool } from "./tools/search-serendie-guideline";
+import { getSearchDesignDocsTools } from "./tools/search-design-docs";
 
 export function createMcpServer() {
   const mcpServer = new McpServer({
@@ -27,6 +28,7 @@ export function createMcpServer() {
   getComponentsTool(mcpServer);
   getComponentDetailTool(mcpServer);
   getSearchSerendieGuidelineTool(mcpServer);
+  getSearchDesignDocsTools(mcpServer);
 
   // Add a simple health check tool
   mcpServer.registerTool(

--- a/src/mcp/tools/search-design-docs.ts
+++ b/src/mcp/tools/search-design-docs.ts
@@ -1,0 +1,191 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod/v3";
+
+const DEFAULT_DOCS_SEARCH_API_ENDPOINT =
+  "https://design-docs-search.takram-spread.workers.dev/api/search";
+
+type SourceFilter = "ark_ui" | "component_gallery" | "m3";
+type WorkerEnv = Record<string, string | undefined>;
+
+interface SearchDocsResponse {
+  results?: unknown[];
+  total?: number;
+}
+
+const getEnvValue = (key: string): string | undefined => {
+  if (typeof process !== "undefined" && process.env?.[key]) {
+    return process.env[key];
+  }
+
+  const globalEnv = (
+    globalThis as typeof globalThis & {
+      __SERENDIE_WORKER_ENV__?: WorkerEnv;
+    }
+  ).__SERENDIE_WORKER_ENV__;
+
+  return globalEnv?.[key];
+};
+
+const removeBase64Data = (value: unknown): unknown => {
+  if (typeof value === "string") {
+    if (value.startsWith("data:image/")) {
+      return "[image data removed]";
+    }
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(removeBase64Data);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [
+        key,
+        removeBase64Data(nestedValue),
+      ])
+    );
+  }
+
+  return value;
+};
+
+const searchDocs = async ({
+  query,
+  nResults,
+  sourceFilters,
+}: {
+  query: string;
+  nResults: number;
+  sourceFilters: SourceFilter[];
+}) => {
+  const endpoint =
+    getEnvValue("DOCS_SEARCH_API_ENDPOINT") ?? DEFAULT_DOCS_SEARCH_API_ENDPOINT;
+  const apiKey = getEnvValue("DOCS_SEARCH_API_KEY");
+
+  const responses = await Promise.all(
+    sourceFilters.map(async (sourceFilter) => {
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (apiKey) {
+        headers["X-API-Key"] = apiKey;
+      }
+
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          query,
+          n_results: nResults,
+          source_filter: sourceFilter,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(
+          JSON.stringify({
+            error: "Doc search request failed",
+            status: response.status,
+            statusText: response.statusText,
+            details: errorText,
+          })
+        );
+      }
+
+      return (await response.json()) as SearchDocsResponse;
+    })
+  );
+
+  const results = responses.flatMap((response) => response.results ?? []);
+
+  return {
+    query,
+    totalResults: results.length,
+    results: removeBase64Data(results),
+  };
+};
+
+const searchDocsParams = {
+  query: z.string().min(1).describe("Plain text query used to search docs."),
+  nResults: z
+    .number()
+    .min(1)
+    .max(20)
+    .optional()
+    .default(5)
+    .describe("Number of results to return. Defaults to 5."),
+};
+
+const createSearchDocsHandler =
+  (sourceFilters: SourceFilter[]) =>
+  async ({ query, nResults }: { query: string; nResults?: number }) => {
+    try {
+      const responseData = await searchDocs({
+        query,
+        nResults: nResults ?? 5,
+        sourceFilters,
+      });
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(responseData, null, 2),
+          },
+        ],
+        structuredContent: responseData,
+        isError: false,
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text:
+              error instanceof Error
+                ? error.message
+                : JSON.stringify({
+                    error: "Failed to execute doc search request",
+                  }),
+          },
+        ],
+        isError: true,
+      };
+    }
+  };
+
+export function getSearchDesignDocsTools(mcpServer: McpServer) {
+  mcpServer.registerTool(
+    "search-component-docs",
+    {
+      title: "Search Component Docs",
+      description:
+        "Search ARK UI and Component Gallery docs for component naming and design patterns.",
+      inputSchema: searchDocsParams,
+      outputSchema: {
+        query: z.string(),
+        totalResults: z.number(),
+        results: z.array(z.unknown()),
+      },
+    },
+    createSearchDocsHandler(["ark_ui", "component_gallery"])
+  );
+
+  mcpServer.registerTool(
+    "search-design-token-docs",
+    {
+      title: "Search Design Token Docs",
+      description:
+        "Search Material Design 3 docs for design token usage and design principles.",
+      inputSchema: searchDocsParams,
+      outputSchema: {
+        query: z.string(),
+        totalResults: z.number(),
+        results: z.array(z.unknown()),
+      },
+    },
+    createSearchDocsHandler(["m3"])
+  );
+}


### PR DESCRIPTION
- search-component-docsとsearch-design-token-docs の2つのツールを追加