### PR TITLE
MCPにdoc-searchツールを追加

### DIFF
--- a/src/mcp/__tests__/tools/search-design-docs.test.ts
+++ b/src/mcp/__tests__/tools/search-design-docs.test.ts
@@ -63,8 +63,16 @@ describe("search design docs MCP tools", () => {
     expect(configs.get("search-component-docs")?.title).toBe(
       "Search Component Docs"
     );
+    expect(configs.get("search-component-docs")?.description).toBe(
+      `コンポーネントの命名や設計のヒントになる参考資料を検索します。
+新規コンポーネントの命名や設計、既存コンポーネントのパターンを理解する際に活用してください。`
+    );
     expect(configs.get("search-design-token-docs")?.title).toBe(
       "Search Design Token Docs"
+    );
+    expect(configs.get("search-design-token-docs")?.description).toBe(
+      `デザイントークンの使用法とデザイン原則を検索します。
+デザイントークンの使用方法を検討・精査するときに使用してください。`
     );
   });
 

--- a/src/mcp/__tests__/tools/search-design-docs.test.ts
+++ b/src/mcp/__tests__/tools/search-design-docs.test.ts
@@ -60,21 +60,21 @@ describe("search design docs MCP tools", () => {
   it("registers component and design token search tools", () => {
     const { configs } = registerTools();
 
-    expect(configs.get("search-external-component-docs")?.title).toBe(
-      "Search External Component Docs"
+    expect(configs.get("search-design-patterns")?.title).toBe(
+      "Search Design Patterns"
     );
-    expect(configs.get("search-external-component-docs")?.description).toBe(
-      `Serendie Design Systemに未定義の新規コンポーネントの命名や設計を検討するため、外部デザインシステムの参考資料を検索します。
-コンポーネントの命名や設計のヒントになる参考資料を検索します。
+    expect(configs.get("search-design-patterns")?.description).toBe(
+      `Ark UIおよびデザインシステムギャラリーサイト (component.gallery) 掲載のコンポーネントを対象に、デザインパターンを検索できます。
+コンポーネントの命名やプロパティやバリアントの種類など、UIコンポーネント設計の参考情報を得ることができます。
 新規コンポーネントの命名や設計、既存コンポーネントのパターンを理解する際に活用してください。
 @serendie/ui の実装・既存コンポーネント利用・SDS準拠判断では、必ず search-serendie-guideline / get-components を優先してください。`
     );
-    expect(configs.get("search-external-design-token-docs")?.title).toBe(
-      "Search External Design Token Docs"
+    expect(configs.get("search-md3-design-token-docs")?.title).toBe(
+      "Search MD3 Design Token Docs"
     );
-    expect(configs.get("search-external-design-token-docs")?.description).toBe(
-      `Serendie Design Systemに未定義の新規トークン設計を検討するため、外部デザインシステムの参考資料を検索します。
-デザイントークンの使用法とデザイン原則を検索します。
+    expect(configs.get("search-md3-design-token-docs")?.description).toBe(
+      `Material Design 3のデザイントークン設計に関するドキュメントを検索できます。
+Serendie Design System (Serendie UI)のデザイントークンは、Material Design 3の設計を踏襲しているため、Serendie UIを使う上での参考情報となります。
 デザイントークンの使用方法を検討・精査するときに使用してください。
 @serendie/design-token の既存トークン利用・SDS準拠判断では、必ず search-serendie-guideline / get-design-tokens を優先してください。`
     );
@@ -101,7 +101,7 @@ describe("search design docs MCP tools", () => {
     } as Response);
 
     const { handlers } = registerTools();
-    const result = await handlers.get("search-external-component-docs")!({
+    const result = await handlers.get("search-design-patterns")!({
       query: "accordion",
       nResults: 3,
     });
@@ -147,7 +147,7 @@ describe("search design docs MCP tools", () => {
     } as Response);
 
     const { handlers } = registerTools();
-    await handlers.get("search-external-design-token-docs")!({
+    await handlers.get("search-md3-design-token-docs")!({
       query: "color role",
     });
 
@@ -174,7 +174,7 @@ describe("search design docs MCP tools", () => {
     } as Response);
 
     const { handlers } = registerTools();
-    const result = await handlers.get("search-external-design-token-docs")!({
+    const result = await handlers.get("search-md3-design-token-docs")!({
       query: "typography",
     });
 

--- a/src/mcp/__tests__/tools/search-design-docs.test.ts
+++ b/src/mcp/__tests__/tools/search-design-docs.test.ts
@@ -60,19 +60,23 @@ describe("search design docs MCP tools", () => {
   it("registers component and design token search tools", () => {
     const { configs } = registerTools();
 
-    expect(configs.get("search-component-docs")?.title).toBe(
-      "Search Component Docs"
+    expect(configs.get("search-external-component-docs")?.title).toBe(
+      "Search External Component Docs"
     );
-    expect(configs.get("search-component-docs")?.description).toBe(
-      `コンポーネントの命名や設計のヒントになる参考資料を検索します。
-新規コンポーネントの命名や設計、既存コンポーネントのパターンを理解する際に活用してください。`
+    expect(configs.get("search-external-component-docs")?.description).toBe(
+      `Serendie Design Systemに未定義の新規コンポーネントの命名や設計を検討するため、外部デザインシステムの参考資料を検索します。
+コンポーネントの命名や設計のヒントになる参考資料を検索します。
+新規コンポーネントの命名や設計、既存コンポーネントのパターンを理解する際に活用してください。
+@serendie/ui の実装・既存コンポーネント利用・SDS準拠判断では、必ず search-serendie-guideline / get-components を優先してください。`
     );
-    expect(configs.get("search-design-token-docs")?.title).toBe(
-      "Search Design Token Docs"
+    expect(configs.get("search-external-design-token-docs")?.title).toBe(
+      "Search External Design Token Docs"
     );
-    expect(configs.get("search-design-token-docs")?.description).toBe(
-      `デザイントークンの使用法とデザイン原則を検索します。
-デザイントークンの使用方法を検討・精査するときに使用してください。`
+    expect(configs.get("search-external-design-token-docs")?.description).toBe(
+      `Serendie Design Systemに未定義の新規トークン設計を検討するため、外部デザインシステムの参考資料を検索します。
+デザイントークンの使用法とデザイン原則を検索します。
+デザイントークンの使用方法を検討・精査するときに使用してください。
+@serendie/design-token の既存トークン利用・SDS準拠判断では、必ず search-serendie-guideline / get-design-tokens を優先してください。`
     );
   });
 
@@ -97,7 +101,7 @@ describe("search design docs MCP tools", () => {
     } as Response);
 
     const { handlers } = registerTools();
-    const result = await handlers.get("search-component-docs")!({
+    const result = await handlers.get("search-external-component-docs")!({
       query: "accordion",
       nResults: 3,
     });
@@ -143,7 +147,9 @@ describe("search design docs MCP tools", () => {
     } as Response);
 
     const { handlers } = registerTools();
-    await handlers.get("search-design-token-docs")!({ query: "color role" });
+    await handlers.get("search-external-design-token-docs")!({
+      query: "color role",
+    });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith(
@@ -168,7 +174,7 @@ describe("search design docs MCP tools", () => {
     } as Response);
 
     const { handlers } = registerTools();
-    const result = await handlers.get("search-design-token-docs")!({
+    const result = await handlers.get("search-external-design-token-docs")!({
       query: "typography",
     });
 

--- a/src/mcp/tools/search-design-docs.ts
+++ b/src/mcp/tools/search-design-docs.ts
@@ -169,11 +169,11 @@ const createSearchDocsHandler =
 
 export function getSearchDesignDocsTools(mcpServer: McpServer) {
   mcpServer.registerTool(
-    "search-external-component-docs",
+    "search-design-patterns",
     {
-      title: "Search External Component Docs",
-      description: `Serendie Design Systemに未定義の新規コンポーネントの命名や設計を検討するため、外部デザインシステムの参考資料を検索します。
-コンポーネントの命名や設計のヒントになる参考資料を検索します。
+      title: "Search Design Patterns",
+      description: `Ark UIおよびデザインシステムギャラリーサイト (component.gallery) 掲載のコンポーネントを対象に、デザインパターンを検索できます。
+コンポーネントの命名やプロパティやバリアントの種類など、UIコンポーネント設計の参考情報を得ることができます。
 新規コンポーネントの命名や設計、既存コンポーネントのパターンを理解する際に活用してください。
 @serendie/ui の実装・既存コンポーネント利用・SDS準拠判断では、必ず search-serendie-guideline / get-components を優先してください。`,
       inputSchema: componentDocsParams,
@@ -187,11 +187,11 @@ export function getSearchDesignDocsTools(mcpServer: McpServer) {
   );
 
   mcpServer.registerTool(
-    "search-external-design-token-docs",
+    "search-md3-design-token-docs",
     {
-      title: "Search External Design Token Docs",
-      description: `Serendie Design Systemに未定義の新規トークン設計を検討するため、外部デザインシステムの参考資料を検索します。
-デザイントークンの使用法とデザイン原則を検索します。
+      title: "Search MD3 Design Token Docs",
+      description: `Material Design 3のデザイントークン設計に関するドキュメントを検索できます。
+Serendie Design System (Serendie UI)のデザイントークンは、Material Design 3の設計を踏襲しているため、Serendie UIを使う上での参考情報となります。
 デザイントークンの使用方法を検討・精査するときに使用してください。
 @serendie/design-token の既存トークン利用・SDS準拠判断では、必ず search-serendie-guideline / get-design-tokens を優先してください。`,
       inputSchema: designTokenDocsParams,

--- a/src/mcp/tools/search-design-docs.ts
+++ b/src/mcp/tools/search-design-docs.ts
@@ -169,11 +169,13 @@ const createSearchDocsHandler =
 
 export function getSearchDesignDocsTools(mcpServer: McpServer) {
   mcpServer.registerTool(
-    "search-component-docs",
+    "search-external-component-docs",
     {
-      title: "Search Component Docs",
-      description: `コンポーネントの命名や設計のヒントになる参考資料を検索します。
-新規コンポーネントの命名や設計、既存コンポーネントのパターンを理解する際に活用してください。`,
+      title: "Search External Component Docs",
+      description: `Serendie Design Systemに未定義の新規コンポーネントの命名や設計を検討するため、外部デザインシステムの参考資料を検索します。
+コンポーネントの命名や設計のヒントになる参考資料を検索します。
+新規コンポーネントの命名や設計、既存コンポーネントのパターンを理解する際に活用してください。
+@serendie/ui の実装・既存コンポーネント利用・SDS準拠判断では、必ず search-serendie-guideline / get-components を優先してください。`,
       inputSchema: componentDocsParams,
       outputSchema: {
         query: z.string(),
@@ -185,11 +187,13 @@ export function getSearchDesignDocsTools(mcpServer: McpServer) {
   );
 
   mcpServer.registerTool(
-    "search-design-token-docs",
+    "search-external-design-token-docs",
     {
-      title: "Search Design Token Docs",
-      description: `デザイントークンの使用法とデザイン原則を検索します。
-デザイントークンの使用方法を検討・精査するときに使用してください。`,
+      title: "Search External Design Token Docs",
+      description: `Serendie Design Systemに未定義の新規トークン設計を検討するため、外部デザインシステムの参考資料を検索します。
+デザイントークンの使用法とデザイン原則を検索します。
+デザイントークンの使用方法を検討・精査するときに使用してください。
+@serendie/design-token の既存トークン利用・SDS準拠判断では、必ず search-serendie-guideline / get-design-tokens を優先してください。`,
       inputSchema: designTokenDocsParams,
       outputSchema: {
         query: z.string(),

--- a/src/mcp/tools/search-design-docs.ts
+++ b/src/mcp/tools/search-design-docs.ts
@@ -107,15 +107,26 @@ const searchDocs = async ({
   };
 };
 
-const searchDocsParams = {
-  query: z.string().min(1).describe("Plain text query used to search docs."),
+const componentDocsParams = {
+  query: z.string().min(1).describe("コンポーネントの検索クエリ"),
   nResults: z
     .number()
     .min(1)
     .max(20)
     .optional()
     .default(5)
-    .describe("Number of results to return. Defaults to 5."),
+    .describe("返される結果の数 (デフォルト: 5)"),
+};
+
+const designTokenDocsParams = {
+  query: z.string().min(1).describe("デザイントークンの検索クエリ"),
+  nResults: z
+    .number()
+    .min(1)
+    .max(20)
+    .optional()
+    .default(5)
+    .describe("返される結果の数 (デフォルト: 5)"),
 };
 
 const createSearchDocsHandler =
@@ -161,9 +172,9 @@ export function getSearchDesignDocsTools(mcpServer: McpServer) {
     "search-component-docs",
     {
       title: "Search Component Docs",
-      description:
-        "Search ARK UI and Component Gallery docs for component naming and design patterns.",
-      inputSchema: searchDocsParams,
+      description: `コンポーネントの命名や設計のヒントになる参考資料を検索します。
+新規コンポーネントの命名や設計、既存コンポーネントのパターンを理解する際に活用してください。`,
+      inputSchema: componentDocsParams,
       outputSchema: {
         query: z.string(),
         totalResults: z.number(),
@@ -177,9 +188,9 @@ export function getSearchDesignDocsTools(mcpServer: McpServer) {
     "search-design-token-docs",
     {
       title: "Search Design Token Docs",
-      description:
-        "Search Material Design 3 docs for design token usage and design principles.",
-      inputSchema: searchDocsParams,
+      description: `デザイントークンの使用法とデザイン原則を検索します。
+デザイントークンの使用方法を検討・精査するときに使用してください。`,
+      inputSchema: designTokenDocsParams,
       outputSchema: {
         query: z.string(),
         totalResults: z.number(),


### PR DESCRIPTION
## 概要
- MCPに `search-component-docs` と `search-design-token-docs` を追加
- 既存doc-search APIを呼び出し、Figmaプラグイン内の既存ツールdescriptionを維持
- doc-searchレスポンス内のbase64画像データを除去
- `.astro/` をESLint対象外に追加

## 確認
- `npm test -- src/mcp/__tests__`
- `npm run build`
- 追加/変更ファイル限定の `eslint`

## 補足
- `npm run lint` 全体は既存の `functions/_middleware.ts`、Figma用script、Panda warningなどで失敗します。今回追加/変更したファイルのlintは通っています。