### PR TITLE
feat: AI Search Workers bindingに統合し外部Worker依存を削除

### DIFF
--- a/src/mcp/__tests__/tools/search-design-docs.test.ts
+++ b/src/mcp/__tests__/tools/search-design-docs.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getSearchDesignDocsTools } from "../../tools/search-design-docs";
+import { setWorkerBindings } from "../../utils/bindings";
 
 type RegisteredHandler = (params: {
   query: string;
@@ -53,6 +54,7 @@ describe("search design docs MCP tools", () => {
     } else {
       process.env.DOCS_SEARCH_API_KEY = originalApiKey;
     }
+    setWorkerBindings({});
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -80,106 +82,164 @@ Serendie Design System (Serendie UI)のデザイントークンは、Material De
     );
   });
 
-  it("searches ark_ui and component_gallery for component docs", async () => {
-    const fetchMock = vi.mocked(fetch);
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        results: [
+  describe("HTTP fetch fallback (no bindings)", () => {
+    it("searches ark_ui and component_gallery for component docs", async () => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          results: [
+            {
+              id: "accordion",
+              score: 0.9,
+              source: "ark_ui",
+              title: "Accordion",
+              url: "https://ark-ui.com/react/docs/components/accordion",
+              text: "Accordion guidance",
+              metadata: { image: "data:image/png;base64,abc" },
+            },
+          ],
+          total: 1,
+        }),
+      } as Response);
+
+      const { handlers } = registerTools();
+      const result = await handlers.get("search-design-patterns")!({
+        query: "accordion",
+        nResults: 3,
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        "https://example.com/api/search",
+        expect.objectContaining({
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-API-Key": "test-api-key",
+          },
+          body: JSON.stringify({
+            query: "accordion",
+            n_results: 3,
+            source_filter: "ark_ui",
+          }),
+        })
+      );
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        "https://example.com/api/search",
+        expect.objectContaining({
+          body: JSON.stringify({
+            query: "accordion",
+            n_results: 3,
+            source_filter: "component_gallery",
+          }),
+        })
+      );
+      expect(result.isError).toBe(false);
+      expect(result.content[0].text).toContain("[image data removed]");
+      expect(result.content[0].text).not.toContain("data:image/png;base64");
+    });
+
+    it("searches m3 for design token docs", async () => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ results: [], total: 0 }),
+      } as Response);
+
+      const { handlers } = registerTools();
+      await handlers.get("search-md3-design-token-docs")!({
+        query: "color role",
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://example.com/api/search",
+        expect.objectContaining({
+          body: JSON.stringify({
+            query: "color role",
+            n_results: 5,
+            source_filter: "m3",
+          }),
+        })
+      );
+    });
+
+    it("returns MCP tool errors when doc-search API fails", async () => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        text: async () => "search failed",
+      } as Response);
+
+      const { handlers } = registerTools();
+      const result = await handlers.get("search-md3-design-token-docs")!({
+        query: "typography",
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Doc search request failed");
+      expect(result.content[0].text).toContain("search failed");
+    });
+  });
+
+  describe("AI Search binding path", () => {
+    it("uses binding when available", async () => {
+      const mockSearch = vi.fn().mockResolvedValue({
+        search_query: "accordion",
+        chunks: [
           {
-            id: "accordion",
+            id: "chunk-1",
+            type: "text",
             score: 0.9,
-            source: "ark_ui",
-            title: "Accordion",
-            url: "https://ark-ui.com/react/docs/components/accordion",
             text: "Accordion guidance",
-            metadata: { image: "data:image/png;base64,abc" },
+            item: {
+              key: "ark_ui/docs-components-accordion.md",
+              metadata: {},
+            },
           },
         ],
-        total: 1,
-      }),
-    } as Response);
+      });
 
-    const { handlers } = registerTools();
-    const result = await handlers.get("search-design-patterns")!({
-      query: "accordion",
-      nResults: 3,
-    });
-
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      1,
-      "https://example.com/api/search",
-      expect.objectContaining({
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-API-Key": "test-api-key",
-        },
-        body: JSON.stringify({
-          query: "accordion",
-          n_results: 3,
-          source_filter: "ark_ui",
+      const mockDb = {
+        prepare: vi.fn().mockReturnValue({
+          bind: vi.fn().mockReturnValue({
+            all: vi.fn().mockResolvedValue({
+              results: [
+                {
+                  url: "https://ark-ui.com/react/docs/components/accordion",
+                  source: "ark_ui",
+                  title: "Accordion",
+                  filename: "ark_ui/docs-components-accordion.md",
+                  metadata_json: "{}",
+                },
+              ],
+            }),
+          }),
         }),
-      })
-    );
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      2,
-      "https://example.com/api/search",
-      expect.objectContaining({
-        body: JSON.stringify({
-          query: "accordion",
-          n_results: 3,
-          source_filter: "component_gallery",
-        }),
-      })
-    );
-    expect(result.isError).toBe(false);
-    expect(result.content[0].text).toContain("[image data removed]");
-    expect(result.content[0].text).not.toContain("data:image/png;base64");
-  });
+      };
 
-  it("searches m3 for design token docs", async () => {
-    const fetchMock = vi.mocked(fetch);
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({ results: [], total: 0 }),
-    } as Response);
+      setWorkerBindings({
+        DESIGN_DOCS_SEARCH: { search: mockSearch } as unknown as AiSearchInstanceService,
+        DESIGN_DOCS_DB: mockDb as unknown as D1Database,
+      });
 
-    const { handlers } = registerTools();
-    await handlers.get("search-md3-design-token-docs")!({
-      query: "color role",
+      const { handlers } = registerTools();
+      const result = await handlers.get("search-design-patterns")!({
+        query: "accordion",
+        nResults: 3,
+      });
+
+      expect(result.isError).toBe(false);
+      expect(mockSearch).toHaveBeenCalledTimes(2);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.totalResults).toBe(2);
+      expect(parsed.results[0].title).toBe("Accordion");
+      expect(parsed.results[0].source).toBe("ark_ui");
     });
-
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://example.com/api/search",
-      expect.objectContaining({
-        body: JSON.stringify({
-          query: "color role",
-          n_results: 5,
-          source_filter: "m3",
-        }),
-      })
-    );
-  });
-
-  it("returns MCP tool errors when doc-search API fails", async () => {
-    const fetchMock = vi.mocked(fetch);
-    fetchMock.mockResolvedValue({
-      ok: false,
-      status: 500,
-      statusText: "Internal Server Error",
-      text: async () => "search failed",
-    } as Response);
-
-    const { handlers } = registerTools();
-    const result = await handlers.get("search-md3-design-token-docs")!({
-      query: "typography",
-    });
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("Doc search request failed");
-    expect(result.content[0].text).toContain("search failed");
   });
 });

--- a/src/mcp/tools/search-design-docs.ts
+++ b/src/mcp/tools/search-design-docs.ts
@@ -1,30 +1,24 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod/v3";
+import { getBinding, getEnvValue } from "../utils/bindings";
 
 const DEFAULT_DOCS_SEARCH_API_ENDPOINT =
   "https://design-docs-search.takram-spread.workers.dev/api/search";
 
 type SourceFilter = "ark_ui" | "component_gallery" | "m3";
-type WorkerEnv = Record<string, string | undefined>;
 
 interface SearchDocsResponse {
   results?: unknown[];
   total?: number;
 }
 
-const getEnvValue = (key: string): string | undefined => {
-  if (typeof process !== "undefined" && process.env?.[key]) {
-    return process.env[key];
-  }
-
-  const globalEnv = (
-    globalThis as typeof globalThis & {
-      __SERENDIE_WORKER_ENV__?: WorkerEnv;
-    }
-  ).__SERENDIE_WORKER_ENV__;
-
-  return globalEnv?.[key];
-};
+interface PageMetadataRow {
+  url: string;
+  source: string;
+  title: string;
+  filename: string;
+  metadata_json: string;
+}
 
 const removeBase64Data = (value: unknown): unknown => {
   if (typeof value === "string") {
@@ -50,7 +44,18 @@ const removeBase64Data = (value: unknown): unknown => {
   return value;
 };
 
-const searchDocs = async ({
+function extractSourceFromFilename(filename: string): string {
+  const parts = filename.split("/");
+  return parts[0] || "unknown";
+}
+
+function extractTitleFromContent(content: unknown): string {
+  if (typeof content !== "string") return "Untitled";
+  const match = content.match(/#\s+(.+)$/m);
+  return match ? match[1].trim() : "Untitled";
+}
+
+async function searchViaBinding({
   query,
   nResults,
   sourceFilters,
@@ -58,7 +63,93 @@ const searchDocs = async ({
   query: string;
   nResults: number;
   sourceFilters: SourceFilter[];
-}) => {
+}): Promise<{ query: string; totalResults: number; results: unknown } | null> {
+  const aiSearch = getBinding("DESIGN_DOCS_SEARCH");
+  const db = getBinding("DESIGN_DOCS_DB");
+  if (!aiSearch) return null;
+
+  const allResults: unknown[] = [];
+
+  for (const sourceFilter of sourceFilters) {
+    const searchResult = await aiSearch.search({
+      messages: [{ role: "user", content: query }],
+      ai_search_options: {
+        retrieval: {
+          max_num_results: nResults,
+          filters: { folder: `${sourceFilter}/` },
+        },
+      },
+    });
+
+    const chunks = searchResult.chunks || [];
+    const filenames = chunks.map((chunk) => chunk.item.key);
+
+    const metadataMap = new Map<string, PageMetadataRow>();
+    if (db && filenames.length > 0) {
+      try {
+        const placeholders = filenames.map(() => "?").join(", ");
+        const rows = await db
+          .prepare(
+            `SELECT url, source, title, filename, metadata_json FROM page_metadata WHERE filename IN (${placeholders})`
+          )
+          .bind(...filenames)
+          .all<PageMetadataRow>();
+        for (const row of rows.results) {
+          metadataMap.set(row.filename, row);
+        }
+      } catch {
+        // D1 unavailable — fall back to content extraction
+      }
+    }
+
+    for (const chunk of chunks) {
+      const filename = chunk.item.key;
+      const source = extractSourceFromFilename(filename);
+      const row = metadataMap.get(filename);
+
+      const text = chunk.text ?? "";
+      const title = row?.title ?? extractTitleFromContent(text);
+      const url = row?.url ?? "";
+
+      let metadata: Record<string, unknown> = { source, url, title };
+      if (row) {
+        try {
+          const parsed = JSON.parse(row.metadata_json);
+          delete parsed.anatomy_image_base64;
+          metadata = { source, url, title, ...parsed };
+        } catch {
+          // parse failure — use default metadata
+        }
+      }
+
+      allResults.push({
+        id: filename.replace(/\.md$/, "").replace(/\//g, "_"),
+        score: chunk.score,
+        source,
+        title,
+        url,
+        text,
+        metadata,
+      });
+    }
+  }
+
+  return {
+    query,
+    totalResults: allResults.length,
+    results: removeBase64Data(allResults),
+  };
+}
+
+async function searchViaHttpFetch({
+  query,
+  nResults,
+  sourceFilters,
+}: {
+  query: string;
+  nResults: number;
+  sourceFilters: SourceFilter[];
+}) {
   const endpoint =
     getEnvValue("DOCS_SEARCH_API_ENDPOINT") ?? DEFAULT_DOCS_SEARCH_API_ENDPOINT;
   const apiKey = getEnvValue("DOCS_SEARCH_API_KEY");
@@ -105,7 +196,17 @@ const searchDocs = async ({
     totalResults: results.length,
     results: removeBase64Data(results),
   };
-};
+}
+
+async function searchDocs(params: {
+  query: string;
+  nResults: number;
+  sourceFilters: SourceFilter[];
+}) {
+  return (
+    (await searchViaBinding(params)) ?? (await searchViaHttpFetch(params))
+  );
+}
 
 const componentDocsParams = {
   query: z.string().min(1).describe("コンポーネントの検索クエリ"),

--- a/src/mcp/tools/search-serendie-guideline.ts
+++ b/src/mcp/tools/search-serendie-guideline.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod/v3";
+import { getBinding, getEnvValue } from "../utils/bindings";
 
 interface CloudflareSearchContent {
   id?: string;
@@ -22,7 +23,6 @@ interface CloudflareSearchAttributes {
 
 interface CloudflareSearchResult {
   file_id?: string;
-  /** 検索結果のURL（例: https://serendie.design/components/text-field） */
   filename?: string;
   score?: number;
   attributes?: CloudflareSearchAttributes;
@@ -45,27 +45,108 @@ interface CloudflareSearchResponse {
 const CLOUDFLARE_API_BASE =
   "https://api.cloudflare.com/client/v4/accounts" as const;
 
-type WorkerEnv = Record<string, string | undefined>;
+interface SearchResult {
+  url: string | null;
+  title: string | null;
+  score: number;
+  content: string;
+}
 
-const getEnvValue = (key: string): string | undefined => {
-  if (typeof process !== "undefined" && process.env?.[key]) {
-    return process.env[key];
+async function searchViaBinding(query: string): Promise<{
+  searchQuery: string;
+  results: SearchResult[];
+} | null> {
+  const binding = getBinding("GUIDELINE_SEARCH");
+  if (!binding) return null;
+
+  const response = await binding.search({
+    messages: [{ role: "user", content: query }],
+  });
+
+  const results: SearchResult[] = response.chunks.map((chunk) => ({
+    url: chunk.item.key ?? null,
+    title:
+      (chunk.item.metadata?.title as string) ??
+      (chunk.item.metadata?.file as { title?: string })?.title ??
+      null,
+    score: chunk.score,
+    content: chunk.text,
+  }));
+
+  return { searchQuery: response.search_query, results };
+}
+
+async function searchViaRestApi(query: string): Promise<{
+  searchQuery: string;
+  results: SearchResult[];
+}> {
+  const accountId = getEnvValue("CF_ACCOUNT_ID");
+  const apiToken = getEnvValue("CF_API_TOKEN");
+  const indexName = getEnvValue("DOCUMENT_SEARCH_INDEX");
+
+  if (!accountId || !apiToken || !indexName) {
+    throw new Error(
+      "CF_ACCOUNT_ID, CF_API_TOKEN, and DOCUMENT_SEARCH_INDEX must be set."
+    );
   }
 
-  const globalEnv = (
-    globalThis as typeof globalThis & {
-      __SERENDIE_WORKER_ENV__?: WorkerEnv;
-    }
-  ).__SERENDIE_WORKER_ENV__;
+  const endpoint = `${CLOUDFLARE_API_BASE}/${accountId}/autorag/rags/${indexName}/search`;
 
-  return globalEnv?.[key];
-};
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiToken}`,
+      Accept: "application/json",
+    },
+    body: JSON.stringify({ query }),
+  });
 
-/**
- * Cloudflare AI Search を利用してドキュメント検索を行い、ヒットした本文を連結して返却する MCP ツール。
- *
- * @param mcpServer - MCP サーバーインスタンス
- */
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      JSON.stringify({
+        error: "Cloudflare AI Search request failed",
+        status: response.status,
+        statusText: response.statusText,
+        details: errorText,
+      })
+    );
+  }
+
+  const json = (await response.json()) as CloudflareSearchResponse;
+
+  if (!json.success) {
+    throw new Error(
+      JSON.stringify({
+        error: "Cloudflare AI Search returned an unsuccessful response",
+        details: json,
+      })
+    );
+  }
+
+  const rawResults = Array.isArray(json.result?.data) ? json.result?.data : [];
+
+  const results: SearchResult[] = rawResults.map((result) => {
+    const texts = (result.content ?? [])
+      .filter(
+        (item): item is CloudflareSearchContent & { text: string } =>
+          item?.type === "text" && typeof item.text === "string"
+      )
+      .map((item) => item.text.trim())
+      .filter((text) => text.length > 0);
+
+    return {
+      url: result.filename ?? null,
+      title: result.attributes?.file?.title ?? null,
+      score: result.score ?? 0,
+      content: texts.join("\n\n"),
+    };
+  });
+
+  return { searchQuery: json.result?.search_query ?? query, results };
+}
+
 export function getSearchSerendieGuidelineTool(mcpServer: McpServer) {
   mcpServer.registerTool(
     "search-serendie-guideline",
@@ -74,9 +155,6 @@ export function getSearchSerendieGuidelineTool(mcpServer: McpServer) {
       description:
         "Search Serendie design guidelines using Cloudflare AI Search and return the merged document content.",
       inputSchema: {
-        /**
-         * 検索したいクエリ文字列
-         */
         query: z
           .string()
           .min(1, "Query must not be empty.")
@@ -106,128 +184,21 @@ export function getSearchSerendieGuidelineTool(mcpServer: McpServer) {
       },
     },
     async ({ query }) => {
-      const accountId = getEnvValue("CF_ACCOUNT_ID");
-      const apiToken = getEnvValue("CF_API_TOKEN");
-      const indexName = getEnvValue("DOCUMENT_SEARCH_INDEX");
-
-      if (!accountId || !apiToken || !indexName) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(
-                {
-                  error: "Missing Cloudflare credentials",
-                  message:
-                    "CF_ACCOUNT_ID, CF_API_TOKEN, and DOCUMENT_SEARCH_INDEX must be set.",
-                },
-                null,
-                2
-              ),
-            },
-          ],
-          isError: true,
-        };
-      }
-
-      const endpoint = `${CLOUDFLARE_API_BASE}/${accountId}/autorag/rags/${indexName}/search`;
-
       try {
-        const startTime = Date.now();
-        const response = await fetch(endpoint, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${apiToken}`,
-            Accept: "application/json",
-          },
-          body: JSON.stringify({
-            query,
-          }),
-        });
+        const { searchQuery, results } =
+          (await searchViaBinding(query)) ??
+          (await searchViaRestApi(query));
 
-        if (!response.ok) {
-          const errorText = await response.text();
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(
-                  {
-                    error: "Cloudflare AI Search request failed",
-                    status: response.status,
-                    statusText: response.statusText,
-                    details: errorText,
-                  },
-                  null,
-                  2
-                ),
-              },
-            ],
-            isError: true,
-          };
-        }
-
-        const json = (await response.json()) as CloudflareSearchResponse;
-
-        if (!json.success) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(
-                  {
-                    error:
-                      "Cloudflare AI Search returned an unsuccessful response",
-                    details: json,
-                  },
-                  null,
-                  2
-                ),
-              },
-            ],
-            isError: true,
-          };
-        }
-
-        const rawResults = Array.isArray(json.result?.data)
-          ? json.result?.data
-          : [];
-
-        // 各検索結果をURL情報付きで構造化
-        const structuredResults = rawResults.map((result) => {
-          const texts = (result.content ?? [])
-            .filter(
-              (item): item is CloudflareSearchContent & { text: string } =>
-                item?.type === "text" && typeof item.text === "string"
-            )
-            .map((item) => item.text.trim())
-            .filter((text) => text.length > 0);
-
-          return {
-            url: result.filename ?? null,
-            title: result.attributes?.file?.title ?? null,
-            score: result.score ?? 0,
-            content: texts.join("\n\n"),
-          };
-        });
-
-        // 全テキストを連結したものも用意（後方互換性のため）
-        const mergedText = structuredResults
+        const mergedContent = results
           .map((r) => r.content)
           .filter((text) => text.length > 0)
           .join("\n\n");
 
-        console.log(
-          `Cloudflare AI Search request completed in ${Date.now() - startTime}ms`
-        );
-
-        // 構造化されたレスポンスを返す
         const responseData = {
-          searchQuery: json.result?.search_query ?? query,
-          totalResults: structuredResults.length,
-          results: structuredResults,
-          mergedContent: mergedText,
+          searchQuery,
+          totalResults: results.length,
+          results,
+          mergedContent,
         };
 
         return {

--- a/src/mcp/utils/bindings.ts
+++ b/src/mcp/utils/bindings.ts
@@ -1,0 +1,40 @@
+/// <reference types="@cloudflare/workers-types" />
+
+export interface WorkerBindings {
+  CF_ACCOUNT_ID?: string;
+  CF_API_TOKEN?: string;
+  DOCUMENT_SEARCH_INDEX?: string;
+  DOCS_SEARCH_API_ENDPOINT?: string;
+  DOCS_SEARCH_API_KEY?: string;
+  GUIDELINE_SEARCH?: AiSearchInstanceService;
+  DESIGN_DOCS_SEARCH?: AiSearchInstanceService;
+  DESIGN_DOCS_DB?: D1Database;
+  [key: string]: unknown;
+}
+
+const GLOBAL_KEY = "__SERENDIE_WORKER_BINDINGS__";
+
+type GlobalWithBindings = typeof globalThis & {
+  [GLOBAL_KEY]?: WorkerBindings;
+};
+
+export function setWorkerBindings(env: WorkerBindings): void {
+  (globalThis as GlobalWithBindings)[GLOBAL_KEY] = env;
+}
+
+export function getBinding<K extends keyof WorkerBindings>(
+  key: K
+): WorkerBindings[K] | undefined {
+  const bindings = (globalThis as GlobalWithBindings)[GLOBAL_KEY];
+  return bindings?.[key] as WorkerBindings[K] | undefined;
+}
+
+export function getEnvValue(key: string): string | undefined {
+  if (typeof process !== "undefined" && process.env?.[key]) {
+    return process.env[key];
+  }
+
+  const bindings = (globalThis as GlobalWithBindings)[GLOBAL_KEY];
+  const value = bindings?.[key];
+  return typeof value === "string" ? value : undefined;
+}

--- a/src/pages/mcp/[...path].ts
+++ b/src/pages/mcp/[...path].ts
@@ -3,6 +3,10 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { StreamableHTTPTransport } from "@hono/mcp";
 import { createMcpServer } from "../../mcp/server";
+import {
+  setWorkerBindings,
+  type WorkerBindings,
+} from "../../mcp/utils/bindings";
 
 // Disable prerendering for API routes
 export const prerender = false;
@@ -15,11 +19,9 @@ app.use("*", cors());
 
 // MCP endpoint
 app.all("/", async (c) => {
-  const workerEnv = c.env as Record<string, string | undefined> | undefined;
+  const workerEnv = c.env as WorkerBindings | undefined;
   if (workerEnv) {
-    (globalThis as typeof globalThis & {
-      __SERENDIE_WORKER_ENV__?: Record<string, string | undefined>;
-    }).__SERENDIE_WORKER_ENV__ = workerEnv;
+    setWorkerBindings(workerEnv);
   }
 
   const mcpServer = createMcpServer();
@@ -53,14 +55,12 @@ export type App = typeof app;
 
 // Astro API route handler
 export const ALL: APIRoute = (context) => {
-  // Cloudflare Pages環境で環境変数を取得
-  // context.locals.runtime.env にCloudflare Workersの環境変数が入っている
-  const cfEnv = (context.locals as { runtime?: { env?: Record<string, string | undefined> } })?.runtime?.env;
+  const cfEnv = (
+    context.locals as { runtime?: { env?: WorkerBindings } }
+  )?.runtime?.env;
 
   if (cfEnv) {
-    (globalThis as typeof globalThis & {
-      __SERENDIE_WORKER_ENV__?: Record<string, string | undefined>;
-    }).__SERENDIE_WORKER_ENV__ = cfEnv;
+    setWorkerBindings(cfEnv);
   }
 
   return app.fetch(context.request, cfEnv);


### PR DESCRIPTION
## Summary

- MCP サーバーの検索ツール3つを Cloudflare AI Search Workers バインディング経由に統合
- 外部 Worker (`design-docs-search`) への HTTP 依存を削除
- REST API (`CF_API_TOKEN`) 経由の呼び出しも置き換え
- バインディング未設定時は既存方式にフォールバック（ローカル開発互換）

### 変更内容

- `src/mcp/utils/bindings.ts` — 新規。バインディングの型定義・セッター・ゲッター
- `src/mcp/tools/search-serendie-guideline.ts` — `GUIDELINE_SEARCH` バインディング優先
- `src/mcp/tools/search-design-docs.ts` — `DESIGN_DOCS_SEARCH` + `DESIGN_DOCS_DB` バインディング優先
- `src/pages/mcp/[...path].ts` — env 受け渡しを `WorkerBindings` 型に統一

### デプロイ時に必要な設定

Cloudflare Pages ダッシュボードで以下のバインディングを追加:

- `GUIDELINE_SEARCH` — AI Search, instance `old-dream-a619`
- `DESIGN_DOCS_SEARCH` — AI Search, instance `design-docs-search`
- `DESIGN_DOCS_DB` — D1, database `design-docs-metadata` (id: `6cb7d01b-2e6f-4c72-8a06-f4da669c0641`)

## Test plan

- [x] `npm run test` 全テスト通過
- [ ] ステージングにデプロイ → バインディング設定 → MCP ツール呼び出し確認
- [ ] 本番デプロイ後、外部 Worker 停止して問題ないこと確認